### PR TITLE
feat: 家計簿アプリの実装

### DIFF
--- a/app/constants/household.ts
+++ b/app/constants/household.ts
@@ -1,0 +1,28 @@
+import type { Category } from '@/app/types/household';
+
+export const INCOME_CATEGORIES: Category[] = ['給与', '副業', 'その他収入'];
+
+export const EXPENSE_CATEGORIES: Category[] = [
+  '食費',
+  '住宅',
+  '光熱費',
+  '通信費',
+  '交通費',
+  '娯楽',
+  '医療',
+  'その他支出',
+];
+
+export const CATEGORY_COLORS: Record<Category, string> = {
+  給与: '#3b82f6',
+  副業: '#10b981',
+  'その他収入': '#8b5cf6',
+  食費: '#ef4444',
+  住宅: '#f59e0b',
+  光熱費: '#06b6d4',
+  通信費: '#ec4899',
+  交通費: '#14b8a6',
+  娯楽: '#a855f7',
+  医療: '#f97316',
+  'その他支出': '#6b7280',
+};

--- a/app/hooks/useTransactions.ts
+++ b/app/hooks/useTransactions.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import type { Transaction } from '@/app/types/household';
+
+const STORAGE_KEY = 'household-transactions';
+
+export function useTransactions() {
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  // Load from localStorage on mount
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        setTransactions(JSON.parse(stored));
+      } catch (error) {
+        console.error('Failed to parse transactions:', error);
+      }
+    }
+    setIsLoaded(true);
+  }, []);
+
+  // Save to localStorage whenever transactions change
+  useEffect(() => {
+    if (isLoaded) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(transactions));
+    }
+  }, [transactions, isLoaded]);
+
+  const addTransaction = (transaction: Omit<Transaction, 'id'>) => {
+    const newTransaction: Transaction = {
+      ...transaction,
+      id: Date.now().toString(),
+    };
+    setTransactions([...transactions, newTransaction]);
+  };
+
+  const updateTransaction = (id: string, updates: Partial<Transaction>) => {
+    setTransactions(
+      transactions.map((t) => (t.id === id ? { ...t, ...updates } : t))
+    );
+  };
+
+  const deleteTransaction = (id: string) => {
+    setTransactions(transactions.filter((t) => t.id !== id));
+  };
+
+  return {
+    transactions,
+    addTransaction,
+    updateTransaction,
+    deleteTransaction,
+    isLoaded,
+  };
+}

--- a/app/household/page.tsx
+++ b/app/household/page.tsx
@@ -1,0 +1,635 @@
+'use client';
+
+import { useState } from 'react';
+import * as Tabs from '@radix-ui/react-tabs';
+import { useTransactions } from '@/app/hooks/useTransactions';
+import {
+  filterTransactionsByMonth,
+  calculateBalance,
+  calculateTotalIncome,
+  calculateTotalExpense,
+  getCategoryStats,
+  formatCurrency,
+  formatDate,
+  getAvailableMonths,
+  getCurrentMonth,
+} from '@/app/utils/household';
+import {
+  INCOME_CATEGORIES,
+  EXPENSE_CATEGORIES,
+  CATEGORY_COLORS,
+} from '@/app/constants/household';
+import type { Transaction, TransactionType, Category } from '@/app/types/household';
+
+export default function HouseholdPage() {
+  const { transactions, addTransaction, updateTransaction, deleteTransaction, isLoaded } =
+    useTransactions();
+  const [selectedMonth, setSelectedMonth] = useState(getCurrentMonth());
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  // New transaction form state
+  const [newType, setNewType] = useState<TransactionType>('expense');
+  const [newCategory, setNewCategory] = useState<Category>('食費');
+  const [newAmount, setNewAmount] = useState('');
+  const [newDate, setNewDate] = useState(getCurrentMonth() + '-01');
+  const [newDescription, setNewDescription] = useState('');
+
+  const monthlyTransactions = filterTransactionsByMonth(transactions, selectedMonth);
+  const totalBalance = calculateBalance(transactions);
+  const monthlyIncome = calculateTotalIncome(monthlyTransactions);
+  const monthlyExpense = calculateTotalExpense(monthlyTransactions);
+  const availableMonths = getAvailableMonths(transactions);
+
+  if (!availableMonths.includes(selectedMonth) && availableMonths.length > 0) {
+    setSelectedMonth(availableMonths[0]);
+  }
+
+  const handleAddTransaction = () => {
+    const amount = parseFloat(newAmount);
+    if (isNaN(amount) || amount <= 0) {
+      alert('有効な金額を入力してください');
+      return;
+    }
+
+    addTransaction({
+      type: newType,
+      category: newCategory,
+      amount,
+      date: newDate,
+      description: newDescription,
+    });
+
+    setNewAmount('');
+    setNewDescription('');
+  };
+
+  const handleDeleteTransaction = (id: string) => {
+    if (confirm('この取引を削除しますか？')) {
+      deleteTransaction(id);
+    }
+  };
+
+  const sortedTransactions = [...monthlyTransactions].sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+  );
+
+  const incomeStats = getCategoryStats(monthlyTransactions, 'income');
+  const expenseStats = getCategoryStats(monthlyTransactions, 'expense');
+
+  if (!isLoaded) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-black py-8 px-4 flex items-center justify-center">
+        <div className="text-gray-600 dark:text-gray-400">読み込み中...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-black py-8 px-4">
+      <div className="max-w-6xl mx-auto">
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-8 text-center">
+          家計簿アプリ
+        </h1>
+
+        <Tabs.Root defaultValue="overview" className="w-full">
+          <Tabs.List className="flex gap-2 mb-6 bg-white dark:bg-gray-800 rounded-lg p-2 shadow-md">
+            <Tabs.Trigger
+              value="overview"
+              className="flex-1 px-6 py-3 rounded-lg font-medium transition-colors data-[state=active]:bg-blue-600 data-[state=active]:text-white data-[state=inactive]:text-gray-700 dark:data-[state=inactive]:text-gray-300 data-[state=inactive]:hover:bg-gray-100 dark:data-[state=inactive]:hover:bg-gray-700"
+            >
+              概要
+            </Tabs.Trigger>
+            <Tabs.Trigger
+              value="history"
+              className="flex-1 px-6 py-3 rounded-lg font-medium transition-colors data-[state=active]:bg-blue-600 data-[state=active]:text-white data-[state=inactive]:text-gray-700 dark:data-[state=inactive]:text-gray-300 data-[state=inactive]:hover:bg-gray-100 dark:data-[state=inactive]:hover:bg-gray-700"
+            >
+              履歴
+            </Tabs.Trigger>
+            <Tabs.Trigger
+              value="breakdown"
+              className="flex-1 px-6 py-3 rounded-lg font-medium transition-colors data-[state=active]:bg-blue-600 data-[state=active]:text-white data-[state=inactive]:text-gray-700 dark:data-[state=inactive]:text-gray-300 data-[state=inactive]:hover:bg-gray-100 dark:data-[state=inactive]:hover:bg-gray-700"
+            >
+              内訳
+            </Tabs.Trigger>
+          </Tabs.List>
+
+          {/* 概要タブ */}
+          <Tabs.Content value="overview" className="space-y-6">
+            {/* 残高カード */}
+            <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-8">
+              <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-4">
+                資産残高
+              </h2>
+              <div className="text-4xl font-bold text-blue-600 dark:text-blue-400">
+                {formatCurrency(totalBalance)}
+              </div>
+            </div>
+
+            {/* 月次統計カード */}
+            <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-8">
+              <div className="flex items-center justify-between mb-6">
+                <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
+                  {selectedMonth}の収支
+                </h2>
+                <select
+                  value={selectedMonth}
+                  onChange={(e) => setSelectedMonth(e.target.value)}
+                  className="px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                >
+                  <option value={getCurrentMonth()}>今月</option>
+                  {availableMonths.map((month) => (
+                    <option key={month} value={month}>
+                      {month}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="bg-green-50 dark:bg-green-900/20 rounded-lg p-4">
+                  <div className="text-sm text-green-800 dark:text-green-300 mb-1">
+                    収入
+                  </div>
+                  <div className="text-2xl font-bold text-green-600 dark:text-green-400">
+                    {formatCurrency(monthlyIncome)}
+                  </div>
+                </div>
+                <div className="bg-red-50 dark:bg-red-900/20 rounded-lg p-4">
+                  <div className="text-sm text-red-800 dark:text-red-300 mb-1">支出</div>
+                  <div className="text-2xl font-bold text-red-600 dark:text-red-400">
+                    {formatCurrency(monthlyExpense)}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* 新規取引追加 */}
+            <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-8">
+              <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-6">
+                新しい取引を追加
+              </h2>
+              <div className="space-y-4">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                      種類
+                    </label>
+                    <select
+                      value={newType}
+                      onChange={(e) => {
+                        setNewType(e.target.value as TransactionType);
+                        setNewCategory(
+                          e.target.value === 'income'
+                            ? INCOME_CATEGORIES[0]
+                            : EXPENSE_CATEGORIES[0]
+                        );
+                      }}
+                      className="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                    >
+                      <option value="expense">支出</option>
+                      <option value="income">収入</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                      カテゴリ
+                    </label>
+                    <select
+                      value={newCategory}
+                      onChange={(e) => setNewCategory(e.target.value as Category)}
+                      className="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                    >
+                      {(newType === 'income'
+                        ? INCOME_CATEGORIES
+                        : EXPENSE_CATEGORIES
+                      ).map((cat) => (
+                        <option key={cat} value={cat}>
+                          {cat}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                      金額
+                    </label>
+                    <input
+                      type="number"
+                      value={newAmount}
+                      onChange={(e) => setNewAmount(e.target.value)}
+                      placeholder="10000"
+                      className="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                      日付
+                    </label>
+                    <input
+                      type="date"
+                      value={newDate}
+                      onChange={(e) => setNewDate(e.target.value)}
+                      className="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                    />
+                  </div>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                    説明
+                  </label>
+                  <input
+                    type="text"
+                    value={newDescription}
+                    onChange={(e) => setNewDescription(e.target.value)}
+                    placeholder="例: スーパーで買い物"
+                    className="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                  />
+                </div>
+                <button
+                  onClick={handleAddTransaction}
+                  className="w-full px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium transition-colors"
+                >
+                  追加
+                </button>
+              </div>
+            </div>
+          </Tabs.Content>
+
+          {/* 履歴タブ */}
+          <Tabs.Content value="history" className="space-y-6">
+            <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-8">
+              <div className="flex items-center justify-between mb-6">
+                <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
+                  取引履歴
+                </h2>
+                <select
+                  value={selectedMonth}
+                  onChange={(e) => setSelectedMonth(e.target.value)}
+                  className="px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                >
+                  <option value={getCurrentMonth()}>今月</option>
+                  {availableMonths.map((month) => (
+                    <option key={month} value={month}>
+                      {month}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {sortedTransactions.length === 0 ? (
+                <div className="text-center py-12 text-gray-500 dark:text-gray-400">
+                  この月の取引はありません
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {sortedTransactions.map((transaction) => (
+                    <TransactionItem
+                      key={transaction.id}
+                      transaction={transaction}
+                      isEditing={editingId === transaction.id}
+                      onEdit={() => setEditingId(transaction.id)}
+                      onCancelEdit={() => setEditingId(null)}
+                      onSave={(updates) => {
+                        updateTransaction(transaction.id, updates);
+                        setEditingId(null);
+                      }}
+                      onDelete={() => handleDeleteTransaction(transaction.id)}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          </Tabs.Content>
+
+          {/* 内訳タブ */}
+          <Tabs.Content value="breakdown" className="space-y-6">
+            <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-8">
+              <div className="flex items-center justify-between mb-6">
+                <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
+                  月次内訳
+                </h2>
+                <select
+                  value={selectedMonth}
+                  onChange={(e) => setSelectedMonth(e.target.value)}
+                  className="px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                >
+                  <option value={getCurrentMonth()}>今月</option>
+                  {availableMonths.map((month) => (
+                    <option key={month} value={month}>
+                      {month}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+                {/* 収入内訳 */}
+                <div>
+                  <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-4">
+                    収入内訳
+                  </h3>
+                  {incomeStats.length === 0 ? (
+                    <div className="text-center py-8 text-gray-500 dark:text-gray-400">
+                      収入データなし
+                    </div>
+                  ) : (
+                    <>
+                      <div className="mb-6">
+                        <PieChart stats={incomeStats} />
+                      </div>
+                      <div className="space-y-2">
+                        {incomeStats.map((stat) => (
+                          <div
+                            key={stat.category}
+                            className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700 rounded-lg"
+                          >
+                            <div className="flex items-center gap-3">
+                              <div
+                                className="w-4 h-4 rounded"
+                                style={{
+                                  backgroundColor: CATEGORY_COLORS[stat.category],
+                                }}
+                              />
+                              <span className="font-medium text-gray-900 dark:text-white">
+                                {stat.category}
+                              </span>
+                            </div>
+                            <div className="text-right">
+                              <div className="font-bold text-gray-900 dark:text-white">
+                                {formatCurrency(stat.amount)}
+                              </div>
+                              <div className="text-sm text-gray-600 dark:text-gray-400">
+                                {stat.percentage.toFixed(1)}%
+                              </div>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </>
+                  )}
+                </div>
+
+                {/* 支出内訳 */}
+                <div>
+                  <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-4">
+                    支出内訳
+                  </h3>
+                  {expenseStats.length === 0 ? (
+                    <div className="text-center py-8 text-gray-500 dark:text-gray-400">
+                      支出データなし
+                    </div>
+                  ) : (
+                    <>
+                      <div className="mb-6">
+                        <PieChart stats={expenseStats} />
+                      </div>
+                      <div className="space-y-2">
+                        {expenseStats.map((stat) => (
+                          <div
+                            key={stat.category}
+                            className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700 rounded-lg"
+                          >
+                            <div className="flex items-center gap-3">
+                              <div
+                                className="w-4 h-4 rounded"
+                                style={{
+                                  backgroundColor: CATEGORY_COLORS[stat.category],
+                                }}
+                              />
+                              <span className="font-medium text-gray-900 dark:text-white">
+                                {stat.category}
+                              </span>
+                            </div>
+                            <div className="text-right">
+                              <div className="font-bold text-gray-900 dark:text-white">
+                                {formatCurrency(stat.amount)}
+                              </div>
+                              <div className="text-sm text-gray-600 dark:text-gray-400">
+                                {stat.percentage.toFixed(1)}%
+                              </div>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </>
+                  )}
+                </div>
+              </div>
+            </div>
+          </Tabs.Content>
+        </Tabs.Root>
+      </div>
+    </div>
+  );
+}
+
+// Transaction Item Component
+interface TransactionItemProps {
+  transaction: Transaction;
+  isEditing: boolean;
+  onEdit: () => void;
+  onCancelEdit: () => void;
+  onSave: (updates: Partial<Transaction>) => void;
+  onDelete: () => void;
+}
+
+function TransactionItem({
+  transaction,
+  isEditing,
+  onEdit,
+  onCancelEdit,
+  onSave,
+  onDelete,
+}: TransactionItemProps) {
+  const [editType, setEditType] = useState(transaction.type);
+  const [editCategory, setEditCategory] = useState(transaction.category);
+  const [editAmount, setEditAmount] = useState(transaction.amount.toString());
+  const [editDate, setEditDate] = useState(transaction.date);
+  const [editDescription, setEditDescription] = useState(transaction.description);
+
+  const handleSave = () => {
+    const amount = parseFloat(editAmount);
+    if (isNaN(amount) || amount <= 0) {
+      alert('有効な金額を入力してください');
+      return;
+    }
+
+    onSave({
+      type: editType,
+      category: editCategory,
+      amount,
+      date: editDate,
+      description: editDescription,
+    });
+  };
+
+  if (isEditing) {
+    return (
+      <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-4 space-y-3">
+        <div className="grid grid-cols-2 gap-3">
+          <select
+            value={editType}
+            onChange={(e) => {
+              setEditType(e.target.value as TransactionType);
+              setEditCategory(
+                e.target.value === 'income' ? INCOME_CATEGORIES[0] : EXPENSE_CATEGORIES[0]
+              );
+            }}
+            className="px-3 py-2 rounded border border-gray-300 dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-600 dark:text-white text-sm"
+          >
+            <option value="expense">支出</option>
+            <option value="income">収入</option>
+          </select>
+          <select
+            value={editCategory}
+            onChange={(e) => setEditCategory(e.target.value as Category)}
+            className="px-3 py-2 rounded border border-gray-300 dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-600 dark:text-white text-sm"
+          >
+            {(editType === 'income' ? INCOME_CATEGORIES : EXPENSE_CATEGORIES).map((cat) => (
+              <option key={cat} value={cat}>
+                {cat}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <input
+            type="number"
+            value={editAmount}
+            onChange={(e) => setEditAmount(e.target.value)}
+            className="px-3 py-2 rounded border border-gray-300 dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-600 dark:text-white text-sm"
+          />
+          <input
+            type="date"
+            value={editDate}
+            onChange={(e) => setEditDate(e.target.value)}
+            className="px-3 py-2 rounded border border-gray-300 dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-600 dark:text-white text-sm"
+          />
+        </div>
+        <input
+          type="text"
+          value={editDescription}
+          onChange={(e) => setEditDescription(e.target.value)}
+          className="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-600 dark:text-white text-sm"
+        />
+        <div className="flex gap-2">
+          <button
+            onClick={handleSave}
+            className="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded text-sm font-medium"
+          >
+            保存
+          </button>
+          <button
+            onClick={onCancelEdit}
+            className="px-4 py-2 bg-gray-600 hover:bg-gray-700 text-white rounded text-sm font-medium"
+          >
+            キャンセル
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-700 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors">
+      <div className="flex-1">
+        <div className="flex items-center gap-3 mb-2">
+          <span
+            className={`px-3 py-1 rounded-full text-xs font-medium ${
+              transaction.type === 'income'
+                ? 'bg-green-200 text-green-800 dark:bg-green-900 dark:text-green-300'
+                : 'bg-red-200 text-red-800 dark:bg-red-900 dark:text-red-300'
+            }`}
+          >
+            {transaction.type === 'income' ? '収入' : '支出'}
+          </span>
+          <span className="font-medium text-gray-900 dark:text-white">
+            {transaction.category}
+          </span>
+          <span className="text-gray-600 dark:text-gray-400 text-sm">
+            {formatDate(transaction.date)}
+          </span>
+        </div>
+        <div className="text-gray-700 dark:text-gray-300 text-sm">
+          {transaction.description || '説明なし'}
+        </div>
+      </div>
+      <div className="flex items-center gap-4">
+        <div
+          className={`text-xl font-bold ${
+            transaction.type === 'income'
+              ? 'text-green-600 dark:text-green-400'
+              : 'text-red-600 dark:text-red-400'
+          }`}
+        >
+          {transaction.type === 'income' ? '+' : '-'}
+          {formatCurrency(transaction.amount)}
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={onEdit}
+            className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            編集
+          </button>
+          <button
+            onClick={onDelete}
+            className="text-sm text-red-600 dark:text-red-400 hover:underline"
+          >
+            削除
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Simple Pie Chart Component
+interface PieChartProps {
+  stats: Array<{
+    category: Category;
+    amount: number;
+    percentage: number;
+  }>;
+}
+
+function PieChart({ stats }: PieChartProps) {
+  let currentAngle = 0;
+  const radius = 80;
+  const centerX = 100;
+  const centerY = 100;
+
+  const slices = stats.map((stat) => {
+    const angle = (stat.percentage / 100) * 360;
+    const startAngle = currentAngle;
+    const endAngle = currentAngle + angle;
+    currentAngle = endAngle;
+
+    const startRad = (startAngle - 90) * (Math.PI / 180);
+    const endRad = (endAngle - 90) * (Math.PI / 180);
+
+    const x1 = centerX + radius * Math.cos(startRad);
+    const y1 = centerY + radius * Math.sin(startRad);
+    const x2 = centerX + radius * Math.cos(endRad);
+    const y2 = centerY + radius * Math.sin(endRad);
+
+    const largeArc = angle > 180 ? 1 : 0;
+
+    const path = `M ${centerX} ${centerY} L ${x1} ${y1} A ${radius} ${radius} 0 ${largeArc} 1 ${x2} ${y2} Z`;
+
+    return {
+      path,
+      color: CATEGORY_COLORS[stat.category],
+      category: stat.category,
+    };
+  });
+
+  return (
+    <svg viewBox="0 0 200 200" className="w-full max-w-sm mx-auto">
+      {slices.map((slice, index) => (
+        <path key={index} d={slice.path} fill={slice.color} stroke="white" strokeWidth="2" />
+      ))}
+    </svg>
+  );
+}

--- a/app/types/household.ts
+++ b/app/types/household.ts
@@ -1,0 +1,37 @@
+export type TransactionType = 'income' | 'expense';
+
+export type Category =
+  | '給与'
+  | '副業'
+  | 'その他収入'
+  | '食費'
+  | '住宅'
+  | '光熱費'
+  | '通信費'
+  | '交通費'
+  | '娯楽'
+  | '医療'
+  | 'その他支出';
+
+export interface Transaction {
+  id: string;
+  type: TransactionType;
+  category: Category;
+  amount: number;
+  date: string; // YYYY-MM-DD format
+  description: string;
+}
+
+export interface MonthlyStats {
+  month: string; // YYYY-MM format
+  totalIncome: number;
+  totalExpense: number;
+  balance: number;
+  transactions: Transaction[];
+}
+
+export interface CategoryStats {
+  category: Category;
+  amount: number;
+  percentage: number;
+}

--- a/app/utils/household.ts
+++ b/app/utils/household.ts
@@ -1,0 +1,77 @@
+import type { Transaction, CategoryStats } from '@/app/types/household';
+
+export function getMonthKey(date: string): string {
+  return date.substring(0, 7); // YYYY-MM
+}
+
+export function filterTransactionsByMonth(
+  transactions: Transaction[],
+  month: string
+): Transaction[] {
+  return transactions.filter((t) => getMonthKey(t.date) === month);
+}
+
+export function calculateTotalIncome(transactions: Transaction[]): number {
+  return transactions
+    .filter((t) => t.type === 'income')
+    .reduce((sum, t) => sum + t.amount, 0);
+}
+
+export function calculateTotalExpense(transactions: Transaction[]): number {
+  return transactions
+    .filter((t) => t.type === 'expense')
+    .reduce((sum, t) => sum + t.amount, 0);
+}
+
+export function calculateBalance(transactions: Transaction[]): number {
+  return calculateTotalIncome(transactions) - calculateTotalExpense(transactions);
+}
+
+export function getCategoryStats(
+  transactions: Transaction[],
+  type: 'income' | 'expense'
+): CategoryStats[] {
+  const filtered = transactions.filter((t) => t.type === type);
+  const total = filtered.reduce((sum, t) => sum + t.amount, 0);
+
+  const categoryMap = new Map<string, number>();
+  filtered.forEach((t) => {
+    const current = categoryMap.get(t.category) || 0;
+    categoryMap.set(t.category, current + t.amount);
+  });
+
+  const stats: CategoryStats[] = Array.from(categoryMap.entries()).map(
+    ([category, amount]) => ({
+      category: category as CategoryStats['category'],
+      amount,
+      percentage: total > 0 ? (amount / total) * 100 : 0,
+    })
+  );
+
+  return stats.sort((a, b) => b.amount - a.amount);
+}
+
+export function formatCurrency(amount: number): string {
+  return `¥${amount.toLocaleString('ja-JP')}`;
+}
+
+export function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('ja-JP', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+export function getAvailableMonths(transactions: Transaction[]): string[] {
+  const months = new Set(transactions.map((t) => getMonthKey(t.date)));
+  return Array.from(months).sort().reverse();
+}
+
+export function getCurrentMonth(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  return `${year}-${month}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "github-pages-demo",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-tabs": "^1.1.13",
         "next": "16.0.4",
         "react": "19.2.0",
         "react-dom": "19.2.0"
@@ -1226,6 +1227,294 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1559,7 +1848,7 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1569,7 +1858,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -2631,7 +2920,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@radix-ui/react-tabs": "^1.1.13",
     "next": "16.0.4",
     "react": "19.2.0",
     "react-dom": "19.2.0"


### PR DESCRIPTION
## 概要

画像のモックアップに基づいた家計簿アプリを実装しました。

## 実装内容

- 概要タブ：資産残高、月次統計、取引追加
- 履歴タブ：取引一覧、編集・削除機能
- 内訳タブ：円グラフとテーブルでのカテゴリ別内訳
- LocalStorageを使用したデータ永続化
- Radix UI Tabsを使用したアクセシブルUI

Closes #3

---

Generated with [Claude Code](https://claude.ai/code)